### PR TITLE
Add support for table DSL method :json

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Create a table:
 
 ```
 class CreateUsers < ActiveRecord::Migration
-  def up
+  def change
     create_table "migration_models" do |t|
       t.string "login", null: false, limit: 24
       t.json "extras"
@@ -48,7 +48,7 @@ or add the column to an existing one:
 
 ```
 class CreateUsers < ActiveRecord::Migration
-  def up
+  def change
     add_column "users", "extras", :json
   end
 end
@@ -66,8 +66,9 @@ end
 then (ab)use the new attribute!:
 
 ```ruby
-user = User.create!(login: "saverio", extras: {"uses" => ["mysql", "json"]})
-user.extras.fetch("uses") # => ["mysql", "json"]
+User.create!(login: "saverio", extras: {"uses" => ["mysql", "json"]})
+# ...
+User.last.extras.fetch("uses") # => ["mysql", "json"]
 ```
 
 Don't forget that JSON doesn't support symbols, therefore, they can be set, but are accessed/loaded as strings.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class CreateUsers < ActiveRecord::Migration
   def up
     create_table "migration_models" do |t|
       t.string "login", null: false, limit: 24
-      t.column "extras", :json
+      t.json "extras"
     end
   end
 end
@@ -73,10 +73,6 @@ user.extras.fetch("uses") # => ["mysql", "json"]
 Don't forget that JSON doesn't support symbols, therefore, they can be set, but are accessed/loaded as strings.
 
 Users are encouraged to have a look at the test suite ([here](spec/json_on_rails/json_attributes_spec.rb) and [here](spec/json_on_rails/arel_methods_spec.rb)) for an exhaustive view of the functionality.
-
-## Limitations
-
-The column creation `t.json <column_name>` syntax is currently unsupported.
 
 [BS img]: https://travis-ci.org/saveriomiroddi/json_on_rails.svg?branch=master
 [CS img]: https://coveralls.io/repos/saveriomiroddi/json_on_rails/badge.png?branch=master

--- a/lib/active_record/connection_adapters/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/schema_definitions.rb
@@ -1,0 +1,24 @@
+module ActiveRecord
+  # Unfortunately, the type shorthands are hardcoded, and the code itself is not encapsulated
+  # in a method, so there's not much design freedom.
+  # See the file `schema_definitions.rb`.
+  #
+  module ConnectionAdapters
+    class TableDefinition
+      def json(*args)
+        options = args.extract_options!
+        column_names = args
+        column_names.each { |name| column(name, :json, options) }
+      end
+    end
+
+    class Table
+      def json(*args)
+        options = args.extract_options!
+        args.each do |column_name|
+          @base.add_column(name, column_name, :json, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/json_on_rails.rb
+++ b/lib/json_on_rails.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 require_relative "active_record/type/json"
+require_relative "active_record/connection_adapters/schema_definitions"
 
 module JsonOnRails; end

--- a/spec/json_on_rails/migrations_spec.rb
+++ b/spec/json_on_rails/migrations_spec.rb
@@ -23,17 +23,34 @@ describe "Migrations" do
   end
 
   context "on table creation" do
-    it "should support the :json data type" do
-      ActiveRecord::Schema.define do
-        create_table "migration_models" do |t|
-          t.string "login", null: false, limit: 24
-          t.column "extras", :json
+    context "using the :column DSL" do
+      it "should support the :json data type" do
+        ActiveRecord::Schema.define do
+          create_table "migration_models" do |t|
+            t.string "login", null: false, limit: 24
+            t.column "extras", :json
+          end
         end
+
+        MigrationModel.reset_column_information
+
+        expect(MigrationModel.columns_hash["extras"].sql_type).to eql("json")
       end
+    end
 
-      MigrationModel.reset_column_information
+    context "using the :type added DSL" do
+      it "should support the :json data type" do
+        ActiveRecord::Schema.define do
+          create_table "migration_models" do |t|
+            t.string "login", null: false, limit: 24
+            t.json "extras"
+          end
+        end
 
-      expect(MigrationModel.columns_hash["extras"].sql_type).to eql("json")
+        MigrationModel.reset_column_information
+
+        expect(MigrationModel.columns_hash["extras"].sql_type).to eql("json")
+      end
     end
   end
 

--- a/spec/setup/db/schema.rb
+++ b/spec/setup/db/schema.rb
@@ -2,6 +2,6 @@
 
 ActiveRecord::Schema.define(version: 20180210000000) do
   create_table "users" do |t|
-    t.column "extras", :json
+    t.json "extras"
   end
 end


### PR DESCRIPTION
Add support for table DSL method `:json`:

    class CreateUsers < ActiveRecord::Migration
      def up
        create_table "migration_models" do |t|
          t.string "login", null: false, limit: 24
          t.json "extras"
        end
      end
    end

Closes #3.