### PR TITLE
Add support for attribute default

### DIFF
--- a/spec/setup/db/schema.rb
+++ b/spec/setup/db/schema.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
-ActiveRecord::Schema.define(version: 20180210000000) do
+ActiveRecord::Schema.define(version: 20180214000000) do
   create_table "users" do |t|
+    t.json "extras"
+  end
+
+  create_table "with_default_users" do |t|
     t.json "extras"
   end
 end

--- a/spec/setup/models/with_default_user.rb
+++ b/spec/setup/models/with_default_user.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class WithDefaultUser < ActiveRecord::Base
+  after_initialize do |instance|
+    instance.extras = {}
+  end
+end


### PR DESCRIPTION
Add JSON attributes default documentation/UTs

Unit tests and documentation have been added, explaining the proper way to set a default.

The alternative implementation is also explained.

Closes #4.