### PR TITLE
Update Travis Ubuntu version to Bionic; remove Ruby 2.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 cache: bundler
 bundler_args: --without tools
 rvm:
-  - 2.1
   - 2.2
   - 2.3
   - 2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: ruby
 cache: bundler
 bundler_args: --without tools
@@ -7,10 +8,6 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
-addons:
-  apt:
-    sources:
-      - mysql-5.7-trusty
-    packages:
-      - mysql-server
+services:
+  - mysql
 sudo: required

--- a/json_on_rails.gemspec
+++ b/json_on_rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = "Add native support for MySQL [5.7] JSON data type to Rails 4."
   s.date        = "2018-02-12"
 
-  s.required_ruby_version = ">= 2.1.0"
+  s.required_ruby_version = ">= 2.2.0"
 
   s.license = "GPL-3.0"
 


### PR DESCRIPTION
Get the Travis update goodies, but most importantly, closes #18.

Ruby 2.1 could have been kept, but with its Travis build failing, it's not worth bothering.